### PR TITLE
Add tiling option

### DIFF
--- a/scripts/relauncher.py
+++ b/scripts/relauncher.py
@@ -19,6 +19,8 @@ optimized_turbo = False
 # Creates a public xxxxx.gradio.app share link to allow others to use your interface (requires properly forwarded ports to work correctly)
 share = False
 
+# Generate tiling images
+tiling = True
 
 # Enter other `--arguments` you wish to use - Must be entered as a `--argument ` syntax
 additional_arguments = ""
@@ -37,6 +39,8 @@ if optimized_turbo == True:
     common_arguments += "--optimized-turbo "
 if optimized == True:
     common_arguments += "--optimized "
+if tiling == True:
+    common_arguments += "--tiling "
 if share == True:
     common_arguments += "--share "
 

--- a/scripts/webui.py
+++ b/scripts/webui.py
@@ -40,6 +40,7 @@ parser.add_argument("--skip-grid", action='store_true', help="do not save a grid
 parser.add_argument("--skip-save", action='store_true', help="do not save indiviual samples. For speed measurements.", default=False)
 parser.add_argument('--no-job-manager', action='store_true', help="Don't use the experimental job manager on top of gradio", default=False)
 parser.add_argument("--max-jobs", type=int, help="Maximum number of concurrent 'generate' commands", default=1)
+parser.add_argument("--tiling", action='store_true', help="Generate tiling images", default=False)
 opt = parser.parse_args()
 
 #Should not be needed anymore
@@ -81,6 +82,19 @@ from torch import autocast
 from ldm.models.diffusion.ddim import DDIMSampler
 from ldm.models.diffusion.plms import PLMSSampler
 from ldm.util import instantiate_from_config
+
+
+# add global options to models
+def patch_conv(**patch):
+    cls = torch.nn.Conv2d
+    init = cls.__init__
+    def __init__(self, *args, **kwargs):
+        return init(self, *args, **kwargs, **patch)
+    cls.__init__ = __init__
+
+if opt.tiling:
+    patch_conv(padding_mode='circular')
+    print("patched for tiling")
 
 try:
     # this silences the annoying "Some weights of the model checkpoint were not used when initializing..." message at start.


### PR DESCRIPTION
Add a --tiling option parameter which patches all models to use padding_mode='circular'. This causes SD to generate tiling images natively, in one go, without extra processing.

![image](https://user-images.githubusercontent.com/2590984/188320964-4d878ce0-1d9d-4546-b548-230e949c33e2.png)

![image](https://user-images.githubusercontent.com/2590984/188321150-2a20134a-89a5-42da-9198-bf1d1ba716e4.png)


It's a parameter because it requires the models to be reinitialized (as far as I know). It's possible to make it into a UI parameter but that would require keeping track of how the model is loaded and reload it on demand etc. Same could be done for other options like "optimized". Probably should be a separate story.

Code modified from https://gitlab.com/-/snippets/2395088

