### PR TITLE
Avoid copying the models, outputs and src when building the image.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+models/
+outputs/
+src/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ services:
     env_file: .env_docker
     volumes:
       - .:/sd
-      - ./outputs:/sd/outputs
       - conda_env:/opt/conda
       - root_profile:/root
     ports:
@@ -18,7 +17,7 @@ services:
       resources:
         reservations:
           devices:
-            - capabilities: [gpu]
+            - capabilities: [ gpu ]
 
 volumes:
   conda_env:


### PR DESCRIPTION
The models, src and outputs are mapped as volumes for docker.